### PR TITLE
Fix Font Awesome 7 build integration

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -9,6 +9,9 @@ module.exports = (eleventyConfig) => {
   eleventyConfig.addPlugin(SyntaxHighlight);
 
   eleventyConfig.addPassthroughCopy("assets");
+  eleventyConfig.addPassthroughCopy({
+    "node_modules/@fortawesome/fontawesome-free/webfonts": "webfonts",
+  });
 
   eleventyConfig.addCollection("posts", (collection) => {
     return collection.getFilteredByGlob("_posts/**/*.md")

--- a/css/fontawesome.less
+++ b/css/fontawesome.less
@@ -1,10 +1,8 @@
-@import "../node_modules/@fortawesome/fontawesome-free/less/_variables.less";
-
-@fa-font-path: "/css";
-
-@import "../node_modules/@fortawesome/fontawesome-free/less/fontawesome.less";
-@import "../node_modules/@fortawesome/fontawesome-free/less/brands.less";
-@import "../node_modules/@fortawesome/fontawesome-free/less/solid.less";
+// Font Awesome 7 provides CSS distributions instead of Less.
+// Import the compiled CSS so that it is bundled into the generated stylesheet.
+@import (less) "../node_modules/@fortawesome/fontawesome-free/css/fontawesome.css";
+@import (less) "../node_modules/@fortawesome/fontawesome-free/css/brands.css";
+@import (less) "../node_modules/@fortawesome/fontawesome-free/css/solid.css";
 
 .fa-2x {
   font-size: 4em;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm-run-all clean site less fonts",
     "site": "eleventy",
     "less": "lessc --source-map-no-annotation ./css/main.less ./_site/css/main.css",
-    "fonts": "copyfiles -f node_modules/@fortawesome/fontawesome-free/webfonts/*.woff* ./_site/css/",
+    "fonts": "copyfiles -f node_modules/@fortawesome/fontawesome-free/webfonts/*.woff* ./_site/webfonts/",
     "clean": "rimraf ./_site/**"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- switch the Font Awesome imports to the distributed CSS assets now that the Less sources were removed in v7
- copy the webfont files into _site/webfonts so the compiled CSS can resolve its font URLs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3bdbdc51c832d8d4f73a50c54df7b